### PR TITLE
Add Java bin into PATH as well

### DIFF
--- a/dev/run-tests-jenkins.py
+++ b/dev/run-tests-jenkins.py
@@ -184,9 +184,10 @@ def main():
     if "test-hadoop3.2" in ghprb_pull_title:
         os.environ["AMPLAB_JENKINS_BUILD_PROFILE"] = "hadoop3.2"
 
-    # Test with Java11
+    # Test with Java 11
     if "test-java11" in ghprb_pull_title:
         os.environ["JAVA_HOME"] = "/usr/java/jdk-11.0.1"
+        os.environ["PATH"] = "%s/bin:%s" % (os.environ["JAVA_HOME"], os.environ["PATH"])
 
     build_display_name = os.environ["BUILD_DISPLAY_NAME"]
     build_url = os.environ["BUILD_URL"]


### PR DESCRIPTION
This PR proposes to add Java 11 bins into PATH. Given some tests https://github.com/apache/spark/pull/25447, looks it uses `java` in Java 8 when it launches local cluster in tests, which leads to test failures. For instance see https://amplab.cs.berkeley.edu/jenkins/job/SparkPullRequestBuilder/109096/console